### PR TITLE
update readme about react-redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ const MyComponent = universal(import(`./my_component`), {
 
 You now have a bulletproof store injection :rocket:
 
-## React Redux >= 6.0.0
+## React Redux ^6.0.0
+
+> **NOTE** this issue was resolved in react-redux@^7
 
 From `react-redux@6.0.0`, there is a huge breaking change regarding the context store.
 After injecting the reducer, it will not be reflected in the `mapStateToProps` method of the `connect` method from redux.


### PR DESCRIPTION
As explained in the README file, there is an issue with react-redux@6.
This issue is explained in more detail in https://github.com/reduxjs/react-redux/issues/1126 where a codesandbox is also provided. Based on that [codesandbox](https://codesandbox.io/s/612k3pv1yz) it seems that the issue is resolved in version 7 (you try changing the version in the codesnadbox)